### PR TITLE
🔀 :: ASO를 위한 앱 이름 변경

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">오늘 뭐임</string>
+    <string name="app_name">오늘 뭐임 - 오늘 급식과 시간표를 한눈에</string>
 </resources>

--- a/feature/root/src/main/res/values/strings.xml
+++ b/feature/root/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="title_activity_main">MainActivity</string>
-    <string name="app_name">오늘 뭐임</string>
+    <string name="app_name">오늘 뭐임 - 오늘 급식과 시간표를 한눈에</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
구글 플레이스토어에서 "급식", "시간표" 등으로 검색했을때 앱이 노출이 되지를 않음.

## 📃 작업내용
ASO 최적화를 위한 앱이름 변경

## 🔀 변경사항
오늘뭐임 => 오늘뭐임 - 오늘 급식과 시간표를 한눈에


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 앱 이름이 "오늘 뭐임"에서 "오늘 뭐임 - 오늘 급식과 시간표를 한눈에"로 업데이트되어, 애플리케이션에 대한 추가 설명이 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->