### PR TITLE
🔀 :: (#74) - 주말 스킵 기능을 제작하였습니다.

### DIFF
--- a/core/database/schemas/com.onmi.database.ONMIDatabase/3.json
+++ b/core/database/schemas/com.onmi.database.ONMIDatabase/3.json
@@ -1,0 +1,78 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "34528f0d9ecfc6bad9e35a514cfcc703",
+    "entities": [
+      {
+        "tableName": "user_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`schoolCode` TEXT NOT NULL, `educationCode` TEXT NOT NULL, `schoolName` TEXT NOT NULL, `schoolType` TEXT NOT NULL DEFAULT '', `grade` INTEGER NOT NULL, `classroom` INTEGER NOT NULL, `department` TEXT NOT NULL, `isSkipWeekend` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`schoolCode`))",
+        "fields": [
+          {
+            "fieldPath": "schoolCode",
+            "columnName": "schoolCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "educationCode",
+            "columnName": "educationCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schoolName",
+            "columnName": "schoolName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schoolType",
+            "columnName": "schoolType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "grade",
+            "columnName": "grade",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classroom",
+            "columnName": "classroom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "department",
+            "columnName": "department",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSkipWeekend",
+            "columnName": "isSkipWeekend",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "schoolCode"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '34528f0d9ecfc6bad9e35a514cfcc703')"
+    ]
+  }
+}

--- a/core/database/schemas/com.onmi.database.ONMIDatabase/4.json
+++ b/core/database/schemas/com.onmi.database.ONMIDatabase/4.json
@@ -1,0 +1,78 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "34528f0d9ecfc6bad9e35a514cfcc703",
+    "entities": [
+      {
+        "tableName": "user_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`schoolCode` TEXT NOT NULL, `educationCode` TEXT NOT NULL, `schoolName` TEXT NOT NULL, `schoolType` TEXT NOT NULL DEFAULT '', `grade` INTEGER NOT NULL, `classroom` INTEGER NOT NULL, `department` TEXT NOT NULL, `isSkipWeekend` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`schoolCode`))",
+        "fields": [
+          {
+            "fieldPath": "schoolCode",
+            "columnName": "schoolCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "educationCode",
+            "columnName": "educationCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schoolName",
+            "columnName": "schoolName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "schoolType",
+            "columnName": "schoolType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "grade",
+            "columnName": "grade",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classroom",
+            "columnName": "classroom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "department",
+            "columnName": "department",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSkipWeekend",
+            "columnName": "isSkipWeekend",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "schoolCode"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '34528f0d9ecfc6bad9e35a514cfcc703')"
+    ]
+  }
+}

--- a/core/database/src/main/java/com/onmi/database/ONMIDatabase.kt
+++ b/core/database/src/main/java/com/onmi/database/ONMIDatabase.kt
@@ -8,9 +8,9 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [UserEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
-    autoMigrations = [AutoMigration(from = 2, to = 3)]
+    autoMigrations = [AutoMigration(from = 3, to = 4)]
 )
 abstract class ONMIDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao

--- a/core/database/src/main/java/com/onmi/database/ONMIDatabase.kt
+++ b/core/database/src/main/java/com/onmi/database/ONMIDatabase.kt
@@ -8,9 +8,9 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [UserEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
-    autoMigrations = [AutoMigration(from = 1, to = 2)]
+    autoMigrations = [AutoMigration(from = 2, to = 3)]
 )
 abstract class ONMIDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao

--- a/core/database/src/main/java/com/onmi/database/UserDao.kt
+++ b/core/database/src/main/java/com/onmi/database/UserDao.kt
@@ -5,11 +5,12 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface UserDao {
     @Query("SELECT * FROM user_table")
-    suspend fun getUserInfo(): UserEntity?
+    fun getUserInfo(): Flow<UserEntity?>
 
     @Transaction
     suspend fun replaceUserInfo(userEntity: UserEntity) {

--- a/core/database/src/main/java/com/onmi/database/UserDao.kt
+++ b/core/database/src/main/java/com/onmi/database/UserDao.kt
@@ -1,12 +1,10 @@
 package com.onmi.database
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import androidx.room.Upsert
 
 @Dao
 interface UserDao {
@@ -24,4 +22,7 @@ interface UserDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertUserInfo(userEntity: UserEntity)
+
+    @Query("UPDATE user_table SET isSkipWeekend = :isSkipWeekend")
+    suspend fun setIsSkipWeekend(isSkipWeekend: Boolean)
 }

--- a/core/database/src/main/java/com/onmi/database/UserEntity.kt
+++ b/core/database/src/main/java/com/onmi/database/UserEntity.kt
@@ -15,4 +15,6 @@ data class UserEntity(
     var grade: Int = 0,
     var classroom: Int = 0,
     var department: String = "",
+    @ColumnInfo(name = "isSkipWeekend", defaultValue = "false")
+    var isSkipWeekend: Boolean = false
 )

--- a/data/src/main/java/com/onmi/data/datasource/TimeTableDataSource.kt
+++ b/data/src/main/java/com/onmi/data/datasource/TimeTableDataSource.kt
@@ -53,10 +53,22 @@ class TimeTableDataSource @Inject constructor(
         }
 
         return when (schoolType) {
-            "els" -> response.body<GetElementarySchoolTimTableResponse>().timetable?.getOrNull(1)?.row?.map { it.subject }
-            "mis" -> response.body<GetMiddleSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row?.map { it.subject }
-            "his" -> response.body<GetHighSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row?.map { it.subject }
-            "sps" -> response.body<GetSpecialSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row?.map { it.subject }
+            "els" -> response.body<GetElementarySchoolTimTableResponse>().timetable?.getOrNull(1)?.row
+                ?.distinctBy { it.period }
+                ?.map { it.subject }
+
+            "mis" -> response.body<GetMiddleSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row
+                ?.distinctBy { it.period }
+                ?.map { it.subject }
+
+            "his" -> response.body<GetHighSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row
+                ?.distinctBy { it.period }
+                ?.map { it.subject }
+
+            "sps" -> response.body<GetSpecialSchoolTimeTableResponse>().timetable?.getOrNull(1)?.row
+                ?.distinctBy { it.period }
+                ?.map { it.subject }
+
             else -> emptyList()
         }
     }

--- a/data/src/main/java/com/onmi/data/dto/timetable/response/GetTimeTableResponse.kt
+++ b/data/src/main/java/com/onmi/data/dto/timetable/response/GetTimeTableResponse.kt
@@ -7,4 +7,6 @@ import kotlinx.serialization.Serializable
 data class GetTimeTableResponse(
     @SerialName("ITRT_CNTNT")
     val subject: String,
+    @SerialName("PERIO")
+    val period: String,
 )

--- a/domain/src/main/java/com/onmi/domain/usecase/meal/GetTodayMealsUseCase.kt
+++ b/domain/src/main/java/com/onmi/domain/usecase/meal/GetTodayMealsUseCase.kt
@@ -3,6 +3,7 @@ package com.onmi.domain.usecase.meal
 import com.onmi.database.UserDao
 import com.onmi.domain.repository.MealRepository
 import com.onmi.domain.util.DateUtils
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -15,7 +16,7 @@ class GetTodayMealsUseCase @Inject constructor(
 ) {
     suspend operator fun invoke() = kotlin.runCatching {
         val userInfo = runBlocking {
-            userDao.getUserInfo()
+            userDao.getUserInfo().first()
         } ?: throw RuntimeException("fail to get user info")
 
         repository.getMeals(

--- a/domain/src/main/java/com/onmi/domain/usecase/meal/GetTodayMealsUseCase.kt
+++ b/domain/src/main/java/com/onmi/domain/usecase/meal/GetTodayMealsUseCase.kt
@@ -2,8 +2,8 @@ package com.onmi.domain.usecase.meal
 
 import com.onmi.database.UserDao
 import com.onmi.domain.repository.MealRepository
+import com.onmi.domain.util.DateUtils
 import kotlinx.coroutines.runBlocking
-import java.lang.RuntimeException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -14,13 +14,15 @@ class GetTodayMealsUseCase @Inject constructor(
     private val userDao: UserDao,
 ) {
     suspend operator fun invoke() = kotlin.runCatching {
-        val userInfo =
-            runBlocking { userDao.getUserInfo() } ?: throw RuntimeException("fail to get user info")
+        val userInfo = runBlocking {
+            userDao.getUserInfo()
+        } ?: throw RuntimeException("fail to get user info")
 
         repository.getMeals(
             educationCode = userInfo.educationCode,
             schoolCode = userInfo.schoolCode,
-            date = convertMillisToDateString(System.currentTimeMillis())
+            date = if (DateUtils.checkIsWeekend() && userInfo.isSkipWeekend) DateUtils.getNextMondayDate()
+            else convertMillisToDateString(System.currentTimeMillis())
         )
     }
 

--- a/domain/src/main/java/com/onmi/domain/usecase/timetable/GetTodayTimeTableUseCase.kt
+++ b/domain/src/main/java/com/onmi/domain/usecase/timetable/GetTodayTimeTableUseCase.kt
@@ -3,6 +3,7 @@ package com.onmi.domain.usecase.timetable
 import com.onmi.database.UserDao
 import com.onmi.domain.repository.TimeTableRepository
 import com.onmi.domain.util.DateUtils
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -15,7 +16,8 @@ class GetTodayTimeTableUseCase @Inject constructor(
 ) {
     suspend operator fun invoke() = kotlin.runCatching {
         val userInfo =
-            runBlocking { userDao.getUserInfo() } ?: throw RuntimeException("fail to get user info")
+            runBlocking { userDao.getUserInfo().first() }
+                ?: throw RuntimeException("fail to get user info")
 
         repository.getTimeTable(
             schoolCode = userInfo.schoolCode,

--- a/domain/src/main/java/com/onmi/domain/usecase/timetable/GetTodayTimeTableUseCase.kt
+++ b/domain/src/main/java/com/onmi/domain/usecase/timetable/GetTodayTimeTableUseCase.kt
@@ -2,6 +2,7 @@ package com.onmi.domain.usecase.timetable
 
 import com.onmi.database.UserDao
 import com.onmi.domain.repository.TimeTableRepository
+import com.onmi.domain.util.DateUtils
 import kotlinx.coroutines.runBlocking
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -23,7 +24,8 @@ class GetTodayTimeTableUseCase @Inject constructor(
             grade = userInfo.grade,
             `class` = userInfo.classroom,
             department = userInfo.department,
-            date = convertMillisToDateString(System.currentTimeMillis()),
+            date = if (DateUtils.checkIsWeekend() && userInfo.isSkipWeekend) DateUtils.getNextMondayDate()
+            else convertMillisToDateString(System.currentTimeMillis()),
         )
     }
 

--- a/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
+++ b/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
@@ -1,0 +1,48 @@
+package com.onmi.domain.util
+
+import android.os.Build
+import java.text.SimpleDateFormat
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Calendar
+import java.util.Locale
+
+object DateUtils {
+    fun checkIsWeekend(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val dayOfWeek = LocalDate.now().dayOfWeek.value
+            dayOfWeek in 6..7
+        } else {
+            val dayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK)
+            dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY
+        }
+    }
+
+    fun getNextMondayDate(): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val today = LocalDate.now()
+            val nextMonday = when (today.dayOfWeek) {
+                DayOfWeek.SATURDAY -> today.plusDays(2)
+                else -> today.plusDays(1)
+            }
+            val formatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.getDefault())
+            nextMonday.format(formatter)
+        } else {
+            val calendar = Calendar.getInstance()
+            val nextMonday = when (calendar.get(Calendar.DAY_OF_WEEK)) {
+                Calendar.SATURDAY -> {
+                    calendar.add(Calendar.DAY_OF_MONTH, 2)
+                    calendar
+                }
+
+                else -> {
+                    calendar.add(Calendar.DAY_OF_MONTH, 1)
+                    calendar
+                }
+            }
+            val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+            formatter.format(nextMonday.time)
+        }
+    }
+}

--- a/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
+++ b/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
@@ -32,11 +32,14 @@ object DateUtils {
             nextMonday.format(formatter)
         } else {
             val calendar = Calendar.getInstance()
-            calendar.add(Calendar.DAY_OF_WEEK, when (calendar.get(Calendar.DAY_OF_WEEK)) {
-                Calendar.SATURDAY -> 2
-                Calendar.SUNDAY -> 1
-                else -> (Calendar.SATURDAY - calendar.get(Calendar.DAY_OF_WEEK) + 2) % 7
-            }
+            calendar.add(
+                Calendar.DAY_OF_WEEK,
+                when (calendar.get(Calendar.DAY_OF_WEEK)) {
+                    Calendar.SATURDAY -> 2
+                    Calendar.SUNDAY -> 1
+                    else -> (Calendar.SATURDAY - calendar.get(Calendar.DAY_OF_WEEK) + 2) % 7
+                }
+            )
             val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
             formatter.format(calendar.time)
         }

--- a/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
+++ b/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
@@ -32,19 +32,13 @@ object DateUtils {
             nextMonday.format(formatter)
         } else {
             val calendar = Calendar.getInstance()
-            val nextMonday = when (calendar.get(Calendar.DAY_OF_WEEK)) {
-                Calendar.SATURDAY -> {
-                    calendar.add(Calendar.DAY_OF_MONTH, 2)
-                    calendar
-                }
-
-                else -> {
-                    calendar.add(Calendar.DAY_OF_MONTH, 1)
-                    calendar
-                }
+            calendar.add(Calendar.DAY_OF_WEEK, when (calendar.get(Calendar.DAY_OF_WEEK)) {
+                Calendar.SATURDAY -> 2
+                Calendar.SUNDAY -> 1
+                else -> (Calendar.SATURDAY - calendar.get(Calendar.DAY_OF_WEEK) + 2) % 7
             }
             val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
-            formatter.format(nextMonday.time)
+            formatter.format(calendar.time)
         }
     }
 }

--- a/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
+++ b/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
@@ -11,8 +11,10 @@ import java.util.Locale
 object DateUtils {
     fun checkIsWeekend(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val dayOfWeek = LocalDate.now().dayOfWeek.value
-            dayOfWeek in 6..7
+            when (LocalDate.now().dayOfWeek) {
+                DayOfWeek.SATURDAY, DayOfWeek.SUNDAY -> true
+                else -> false
+            }
         } else {
             val dayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK)
             dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY

--- a/feature/root/src/main/java/khs/onmi/root/MainViewModel.kt
+++ b/feature/root/src/main/java/khs/onmi/root/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onmi.database.UserDao
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -14,7 +15,7 @@ class MainViewModel @Inject constructor(
 ) : ViewModel() {
     fun checkUserAlreadyEnteredInfo(action: (isEntered: Boolean) -> Unit) = viewModelScope.launch {
         kotlin.runCatching {
-            userDao.getUserInfo()
+            userDao.getUserInfo().first()
         }.onSuccess {
             action(it != null)
         }.onFailure {

--- a/feature/setting/src/main/java/khs/onmi/setting/component/ToggleItem.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/component/ToggleItem.kt
@@ -1,6 +1,5 @@
 package khs.onmi.setting.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
@@ -15,7 +14,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import khs.onmi.core.designsystem.icon.RiceIcon

--- a/feature/setting/src/main/java/khs/onmi/setting/component/ToggleItem.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/component/ToggleItem.kt
@@ -1,0 +1,72 @@
+package khs.onmi.setting.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import khs.onmi.core.designsystem.icon.RiceIcon
+import khs.onmi.core.designsystem.theme.ONMITheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToggleItem(
+    icon: @Composable () -> Unit,
+    title: String,
+    value: Boolean,
+    onValueChange: (value: Boolean) -> Unit
+) {
+    ONMITheme { color, typography ->
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            icon()
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = title,
+                style = typography.Body3,
+                color = color.Black
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+                Switch(
+                    checked = value,
+                    onCheckedChange = onValueChange,
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = color.White,
+                        uncheckedThumbColor = color.White,
+                        checkedTrackColor = color.Black,
+                        uncheckedTrackColor = color.UnselectedSecondary,
+                        uncheckedBorderColor = color.UnselectedSecondary
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ToggleItemPre() {
+    val (value, onValueChange) = remember { mutableStateOf(false) }
+
+    ONMITheme { color, _ ->
+        ToggleItem(
+            icon = { RiceIcon(tint = color.Black) },
+            title = "저녁 후 내일 급식 표시",
+            value = value,
+            onValueChange = onValueChange
+        )
+    }
+}

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingRoute.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingRoute.kt
@@ -1,24 +1,45 @@
 package khs.onmi.setting.screen
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import khs.onmi.core.common.android.EventLogger
 import khs.onmi.core.common.android.Screen
 import khs.onmi.navigation.ONMINavRoutes
 import khs.onmi.setting.viewmodel.SettingViewModel
+import khs.onmi.setting.viewmodel.container.SettingSideEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SettingRoute(
     navController: NavController,
-    viewModel: SettingViewModel = hiltViewModel()
+    viewModel: SettingViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val uiState = viewModel.container.stateFlow.collectAsState().value
 
     LaunchedEffect(key1 = Unit) {
+        viewModel.container.sideEffectFlow.collectLatest {
+            when (it) {
+                is SettingSideEffect.ShowToast -> {
+                    Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(key1 = Unit) {
         EventLogger.pageShowed(Screen.SETTING)
+    }
+
+    LaunchedEffect(key1 = uiState.isSkipWeekend) {
+        delay(300)
+        viewModel.setIsSkipWeekend(uiState.isSkipWeekend)
     }
 
     SettingScreen(

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingRoute.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingRoute.kt
@@ -21,9 +21,10 @@ fun SettingRoute(
         EventLogger.pageShowed(Screen.SETTING)
     }
 
-    MainScreen(
+    SettingScreen(
         uiState = uiState,
+        onBackPressed = { navController.popBackStack() },
         onEnterInformationClick = { navController.navigate(ONMINavRoutes.EnterInformation.MAIN) },
-        onBackPressed = { navController.popBackStack() }
+        onSkipWeekendToggleValueChanged = viewModel::onSkipWeekendToggleValueChanged
     )
 }

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
@@ -32,7 +31,6 @@ import khs.onmi.setting.component.ToggleItem
 import khs.onmi.setting.model.SettingItemsData
 import khs.onmi.setting.util.WebLink
 import khs.onmi.setting.viewmodel.container.SettingState
-import kotlinx.coroutines.delay
 
 @Composable
 fun SettingScreen(
@@ -113,7 +111,7 @@ fun SettingScreen(
                     ToggleItem(
                         icon = { RiceIcon(tint = color.Black) },
                         title = "주말 건너뛰기",
-                        value = uiState.skipWeekend,
+                        value = uiState.isSkipWeekend,
                         onValueChange = onSkipWeekendToggleValueChanged
                     )
                 }

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
@@ -1,6 +1,7 @@
 package khs.onmi.setting.screen
 
 import android.app.Activity
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +12,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalUriHandler
@@ -19,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import khs.onmi.core.designsystem.component.TopNavigationBar
 import khs.onmi.core.designsystem.icon.ArrowBackIcon
 import khs.onmi.core.designsystem.icon.PaperIcon
+import khs.onmi.core.designsystem.icon.RiceIcon
 import khs.onmi.core.designsystem.icon.RightArrowIcon
 import khs.onmi.core.designsystem.icon.SchoolIcon
 import khs.onmi.core.designsystem.modifier.onmiClickable
@@ -26,6 +30,7 @@ import khs.onmi.core.designsystem.theme.ONMITheme
 import khs.onmi.core.designsystem.utils.WrappedIconButton
 import khs.onmi.setting.component.RoundedWhiteBox
 import khs.onmi.setting.component.SettingListComponent
+import khs.onmi.setting.component.ToggleItem
 import khs.onmi.setting.model.SettingItemsData
 import khs.onmi.setting.util.WebLink
 import khs.onmi.setting.viewmodel.container.SettingState
@@ -36,6 +41,7 @@ fun MainScreen(
     onEnterInformationClick: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
+    val (value, onValueChange) = remember { mutableStateOf(false) }
     val uriHandler = LocalUriHandler.current
     val view = LocalView.current
 
@@ -65,7 +71,8 @@ fun MainScreen(
                     top = it.calculateTopPadding().value.dp,
                     start = 15.dp,
                     end = 15.dp
-                )
+                ),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
@@ -73,7 +80,7 @@ fun MainScreen(
                     style = typography.Headline1,
                     color = color.Black
                 )
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(4.dp))
                 RoundedWhiteBox(onClick = onEnterInformationClick) {
                     Column(modifier = Modifier.fillMaxWidth()) {
                         SchoolIcon(tint = color.Black)
@@ -91,7 +98,6 @@ fun MainScreen(
                         )
                     }
                 }
-                Spacer(modifier = Modifier.height(8.dp))
                 RoundedWhiteBox {
                     SettingListComponent(
                         items = listOf(
@@ -102,6 +108,14 @@ fun MainScreen(
                                 onClick = { uriHandler.openUri(WebLink.PolicyUrl) }
                             )
                         )
+                    )
+                }
+                RoundedWhiteBox {
+                    ToggleItem(
+                        icon = { RiceIcon(tint = color.Black) },
+                        title = "주말 건너뛰기",
+                        value = value,
+                        onValueChange = onValueChange
                     )
                 }
             }

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
@@ -11,9 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalUriHandler
@@ -25,7 +24,6 @@ import khs.onmi.core.designsystem.icon.PaperIcon
 import khs.onmi.core.designsystem.icon.RiceIcon
 import khs.onmi.core.designsystem.icon.RightArrowIcon
 import khs.onmi.core.designsystem.icon.SchoolIcon
-import khs.onmi.core.designsystem.modifier.onmiClickable
 import khs.onmi.core.designsystem.theme.ONMITheme
 import khs.onmi.core.designsystem.utils.WrappedIconButton
 import khs.onmi.setting.component.RoundedWhiteBox
@@ -34,14 +32,15 @@ import khs.onmi.setting.component.ToggleItem
 import khs.onmi.setting.model.SettingItemsData
 import khs.onmi.setting.util.WebLink
 import khs.onmi.setting.viewmodel.container.SettingState
+import kotlinx.coroutines.delay
 
 @Composable
-fun MainScreen(
+fun SettingScreen(
     uiState: SettingState,
-    onEnterInformationClick: () -> Unit,
     onBackPressed: () -> Unit,
+    onEnterInformationClick: () -> Unit,
+    onSkipWeekendToggleValueChanged: (value: Boolean) -> Unit,
 ) {
-    val (value, onValueChange) = remember { mutableStateOf(false) }
     val uriHandler = LocalUriHandler.current
     val view = LocalView.current
 
@@ -114,8 +113,8 @@ fun MainScreen(
                     ToggleItem(
                         icon = { RiceIcon(tint = color.Black) },
                         title = "주말 건너뛰기",
-                        value = value,
-                        onValueChange = onValueChange
+                        value = uiState.skipWeekend,
+                        onValueChange = onSkipWeekendToggleValueChanged
                     )
                 }
             }

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
@@ -47,8 +47,15 @@ class SettingViewModel @Inject constructor(
             }
     }
 
+    suspend fun setIsSkipWeekend(isSkipWeekend: Boolean) = intent {
+        runCatching {
+            onmiDao.setIsSkipWeekend(isSkipWeekend = isSkipWeekend)
+        }.onFailure {
+            postSideEffect(SettingSideEffect.ShowToast("주말 건너뛰기 여부를 설정하지 못하였습니다."))
+        }
+    }
+
     fun onSkipWeekendToggleValueChanged(value: Boolean) = intent {
-        onmiDao.setIsSkipWeekend(isSkipWeekend = value)
         reduce {
             state.copy(isSkipWeekend = value)
         }

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
@@ -5,6 +5,7 @@ import com.onmi.database.UserDao
 import dagger.hilt.android.lifecycle.HiltViewModel
 import khs.onmi.setting.viewmodel.container.SettingSideEffect
 import khs.onmi.setting.viewmodel.container.SettingState
+import kotlinx.coroutines.flow.collectLatest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -29,17 +30,19 @@ class SettingViewModel @Inject constructor(
         kotlin.runCatching {
             onmiDao.getUserInfo()
         }.onSuccess {
-            if (it != null) {
-                reduce {
-                    state.copy(
-                        schoolName = it.schoolName,
-                        grade = it.grade,
-                        `class` = it.classroom,
-                        isSkipWeekend = it.isSkipWeekend
-                    )
+            it.collectLatest { userEntity ->
+                if (userEntity != null) {
+                    reduce {
+                        state.copy(
+                            schoolName = userEntity.schoolName,
+                            grade = userEntity.grade,
+                            `class` = userEntity.classroom,
+                            isSkipWeekend = userEntity.isSkipWeekend
+                        )
+                    }
+                } else {
+                    postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
                 }
-            } else {
-                postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
             }
         }.onFailure {
             postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
@@ -44,4 +44,10 @@ class SettingViewModel @Inject constructor(
             postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
         }
     }
+
+    fun onSkipWeekendToggleValueChanged(value: Boolean) = intent {
+        reduce {
+            state.copy(skipWeekend = value)
+        }
+    }
 }

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
@@ -5,6 +5,7 @@ import com.onmi.database.UserDao
 import dagger.hilt.android.lifecycle.HiltViewModel
 import khs.onmi.setting.viewmodel.container.SettingSideEffect
 import khs.onmi.setting.viewmodel.container.SettingState
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -27,10 +28,10 @@ class SettingViewModel @Inject constructor(
     }
 
     private fun getUserInfo() = intent {
-        kotlin.runCatching {
-            onmiDao.getUserInfo()
-        }.onSuccess {
-            it.collectLatest { userEntity ->
+        onmiDao.getUserInfo()
+            .catch {
+                postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
+            }.collectLatest { userEntity ->
                 if (userEntity != null) {
                     reduce {
                         state.copy(
@@ -44,9 +45,6 @@ class SettingViewModel @Inject constructor(
                     postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
                 }
             }
-        }.onFailure {
-            postSideEffect(SettingSideEffect.ShowToast("사용자 정보를 가져오는데 실패했습니다."))
-        }
     }
 
     fun onSkipWeekendToggleValueChanged(value: Boolean) = intent {

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/SettingViewModel.kt
@@ -34,7 +34,8 @@ class SettingViewModel @Inject constructor(
                     state.copy(
                         schoolName = it.schoolName,
                         grade = it.grade,
-                        `class` = it.classroom
+                        `class` = it.classroom,
+                        isSkipWeekend = it.isSkipWeekend
                     )
                 }
             } else {
@@ -46,8 +47,9 @@ class SettingViewModel @Inject constructor(
     }
 
     fun onSkipWeekendToggleValueChanged(value: Boolean) = intent {
+        onmiDao.setIsSkipWeekend(isSkipWeekend = value)
         reduce {
-            state.copy(skipWeekend = value)
+            state.copy(isSkipWeekend = value)
         }
     }
 }

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/container/SettingState.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/container/SettingState.kt
@@ -4,5 +4,5 @@ data class SettingState(
     val schoolName: String = "",
     val grade: Int = 0,
     val `class`: Int = 0,
-    val skipWeekend: Boolean = false,
+    val isSkipWeekend: Boolean = false,
 )

--- a/feature/setting/src/main/java/khs/onmi/setting/viewmodel/container/SettingState.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/viewmodel/container/SettingState.kt
@@ -4,4 +4,5 @@ data class SettingState(
     val schoolName: String = "",
     val grade: Int = 0,
     val `class`: Int = 0,
+    val skipWeekend: Boolean = false,
 )


### PR DESCRIPTION
## 💡 개요
- 주말 스킵 기능 제작

## 📃 작업내용
- 주말 스킵 기능을 제작하였습니다.

## 🔀 변경사항
- 로컬 DB상태를 가져오는 형식을 flow로 변경하여 로컬DB가 변경되면 메인 리스트를 갱신하는 로직을 추가하였습니다.
- period(교시) 값이 같은 아이템이 있다면 중복을 제거하는 로직을 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **새로운 기능**
	- `user_table` 테이블 추가: 사용자 관련 속성 저장 (학교 코드, 교육 코드 등).
	- 사용자가 주말을 건너뛰는 설정을 위한 토글 기능 추가.
	- 새로운 `ToggleItem` UI 컴포넌트 도입.
	- 사용자 정보 조회를 위한 비동기 흐름 개선.
	- `DateUtils` 유틸리티 함수 추가: 주말 확인 및 다음 월요일 날짜 계산.
- **버그 수정**
	- 사용자 정보 조회 로직 개선: 비동기 흐름으로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->