### PR TITLE
🔀 :: (#114) - 설정 페이지 인 앱 위젯 추가 진입점 재 추가

### DIFF
--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
@@ -102,12 +102,12 @@ fun SettingScreen(
                 RoundedWhiteBox {
                     SettingListComponent(
                         items = listOf(
-//                            SettingItemsData(
-//                                trailing = { RightArrowIcon(tint = color.UnselectedPrimary) },
-//                                text = "위젯 추가",
-//                                leading = { WidgetAddIcon(tint = color.Black) },
-//                                onClick = onAddWidgetClick
-//                            ),
+                            SettingItemsData(
+                                trailing = { RightArrowIcon(tint = color.UnselectedPrimary) },
+                                text = "위젯 추가",
+                                leading = { WidgetAddIcon(tint = color.Black) },
+                                onClick = onAddWidgetClick
+                            ),
                             SettingItemsData(
                                 trailing = { RightArrowIcon(tint = color.UnselectedPrimary) },
                                 text = "이용 약관",


### PR DESCRIPTION
## 💡 개요
- 설정페이지의 인앱 위젯 추가 진입점을 재 추가하였습니다.

## 📃 작업내용
- 인앱 위젯 추가 진입점의 주석 제거

## 🔀 변경사항

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 설정 화면에 "위젯 추가" 항목이 다시 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->