### PR TITLE
🔧 :: (#134) - Firebase 프로젝트 dev/prod 분리 및 Crashlytics 도입

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -33,9 +33,11 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Prepare Environment
+      - name: Inject google-services.json per variant
         run: |
-          echo '${{ secrets.GOOGLE_SERVICES }}' > app/google-services.json;
+          mkdir -p app/src/debug app/src/release
+          echo '${{ secrets.GOOGLE_SERVICES_DEV }}' > app/src/debug/google-services.json
+          echo '${{ secrets.GOOGLE_SERVICES_PROD }}' > app/src/release/google-services.json
 
       - name: Decode Keystore
         run: |

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -34,10 +34,16 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Inject google-services.json per variant
+        env:
+          GOOGLE_SERVICES_DEV: ${{ secrets.GOOGLE_SERVICES_DEV }}
+          GOOGLE_SERVICES_PROD: ${{ secrets.GOOGLE_SERVICES_PROD }}
         run: |
+          set -euo pipefail
+          : "${GOOGLE_SERVICES_DEV:?GOOGLE_SERVICES_DEV secret is required}"
+          : "${GOOGLE_SERVICES_PROD:?GOOGLE_SERVICES_PROD secret is required}"
           mkdir -p app/src/debug app/src/release
-          echo '${{ secrets.GOOGLE_SERVICES_DEV }}' > app/src/debug/google-services.json
-          echo '${{ secrets.GOOGLE_SERVICES_PROD }}' > app/src/release/google-services.json
+          printf '%s' "$GOOGLE_SERVICES_DEV" > app/src/debug/google-services.json
+          printf '%s' "$GOOGLE_SERVICES_PROD" > app/src/release/google-services.json
 
       - name: Decode Keystore
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("khs.onmi.application")
     id("khs.onmi.hilt")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 val keyProperties = Properties().apply {
@@ -59,4 +60,5 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
     alias(libs.plugins.com.google.gms.google.services) apply false
+    alias(libs.plugins.com.google.firebase.crashlytics) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/core/common-android/build.gradle.kts
+++ b/core/common-android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("khs.onmi.library")
-    id("com.google.gms.google-services")
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidxNavigationCompose = "2.9.2"
 androidxWorkManager = "2.10.2"
 datastore = "1.1.7"
 firebaseBom = "33.16.0"
+firebaseCrashlyticsPlugin = "3.0.5"
 glance = "1.1.1"
 googleServices = "4.4.3"
 hilt = "2.56"
@@ -73,6 +74,7 @@ androidx-datastore-preferences-core = { group = "androidx.datastore", name = "da
 # firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 # plugin
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -90,6 +92,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 com-google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 com-google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+com-google-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 
 
 [bundles]


### PR DESCRIPTION
## 💡 개요
- dev / prod Firebase 프로젝트를 **완전히 분리**하고 **Crashlytics를 도입**
- 기존: 단일 프로젝트(`todaywhat-d9a01`) 내 2개 앱(`com.onmi.aos`, `com.onmi.aos.dev`)으로 구분 → Analytics·Crashlytics·DB가 한 프로젝트에 혼재
- 변경: Build Type별로 완전히 분리된 Firebase 프로젝트 사용 → 환경 격리 / 대시보드 분리 / 권한 분리 확보
- CI 파이프라인도 분리된 주입 방식으로 재구성

## 📃 작업내용
- `google-services.json`을 소스셋 기반으로 분리
  - `app/src/debug/google-services.json` → dev 프로젝트 `todaywhat-devstaging`
  - `app/src/release/google-services.json` → prod 프로젝트 `todaywhat-d9a01`
  - Gradle `google-services` 플러그인이 variant별로 자동 매칭
- `core/common-android`의 잘못 적용돼 있던 `com.google.gms.google-services` 플러그인 제거
  - 라이브러리 모듈에는 불필요 (app 모듈의 Firebase 초기화를 공유)
- Firebase Crashlytics 통합
  - `gradle/libs.versions.toml`에 `firebase-crashlytics` 라이브러리 + `com.google.firebase.crashlytics` Gradle 플러그인(3.0.5) alias 추가
  - Firebase BoM 33.16.0 기반 자동 해석 → 현재 `firebase-crashlytics:19.4.4`
  - 루트 `build.gradle.kts`에 `apply false`, `app/build.gradle.kts`에 플러그인 적용 + 의존성 추가
  - `ONMIApplication.onCreate`의 기존 `FirebaseApp.initializeApp`으로 자동 초기화됨 (Application 코드 변경 없음)
- CI 워크플로 업데이트
  - `.github/workflows/android_ci.yml`: 단일 `secrets.GOOGLE_SERVICES` 주입 → `GOOGLE_SERVICES_DEV` / `GOOGLE_SERVICES_PROD` 변종별 주입으로 분리

## 🔀 변경사항
- `app/google-services.json` 삭제 → `app/src/{debug,release}/google-services.json` 로 이동·분리 (gitignore 대상)
- `core/common-android/build.gradle.kts` — google-services 플러그인 제거
- `app/build.gradle.kts` — Crashlytics 플러그인 + `implementation(libs.firebase.crashlytics)` 추가
- `build.gradle.kts` (루트) — Crashlytics 플러그인 `apply false` 추가
- `gradle/libs.versions.toml` — `firebaseCrashlyticsPlugin` 버전 ref + `firebase-crashlytics` 라이브러리 + `com-google-firebase-crashlytics` 플러그인 alias
- `.github/workflows/android_ci.yml` — google-services.json 주입을 variant별 소스셋으로 분리

### 커밋 이력
- `d50f648` 🔧 :: dev/prod Firebase 프로젝트 분리 구성
- `7e89332` ✨ :: Firebase Crashlytics 통합 (BoM 해석 유지)
- `fabdada` 👷 :: CI에서 build type별 google-services.json 주입하도록 변경

## 🎸 기타
### 머지 전 / 머지 시 필요한 운영 작업
1. **GitHub Repository Secrets 신규 등록** (필수 — 미등록 시 CI 빌드 실패)
   - `GOOGLE_SERVICES_DEV` ← dev Firebase 프로젝트 `todaywhat-devstaging`의 `google-services.json` 내용
   - `GOOGLE_SERVICES_PROD` ← prod Firebase 프로젝트 `todaywhat-d9a01`의 `google-services.json` 내용
   - 기존 `GOOGLE_SERVICES` secret은 더 이상 참조되지 않음 → 삭제 권장
2. **Firebase Console**에서 두 프로젝트 모두 Crashlytics 활성화 토글
3. **실기기 스모크 테스트**: 의도적 크래시 유발 후 각 Firebase 프로젝트 Crashlytics 대시보드에 수신되는지 확인

### 참고
- `minifyEnabled = false` 상태라 현재 Crashlytics mapping 파일 업로드는 불필요. 추후 R8 활성화 시 `firebaseCrashlytics { mappingFileUploadEnabled = true }` + CI 인증 세팅 필요 (별도 작업)
- SHA-1 지문 등록은 Google Sign-In / Dynamic Links 같은 SHA 검증 기능 쓸 때만 필요. Analytics·Crashlytics 단독이면 불필요. debug keystore는 개발자별 고유이므로 필요 시 각자 등록
- google-services.json 파일 자체는 `app/.gitignore`의 블랭킷 규칙으로 커밋되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * Firebase Crashlytics를 앱에 통합하여 향상된 충돌 보고 및 분석 기능 추가

* **Chores**
  * 빌드 구성 및 CI/CD 워크플로우 최적화로 개발/배포 환경 분리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->