### PR TITLE
🐛 :: 외부 URI 호출 크래시 방지를 위한 safeOpenUri 유틸 추가

### DIFF
--- a/core/common-android/src/main/java/khs/onmi/core/common/android/SafeUri.kt
+++ b/core/common-android/src/main/java/khs/onmi/core/common/android/SafeUri.kt
@@ -1,0 +1,18 @@
+package khs.onmi.core.common.android
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+fun Context.safeOpenUri(
+    uri: String,
+    addNewTaskFlag: Boolean = false,
+    onError: ((Throwable) -> Unit)? = null,
+): Boolean {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+        if (addNewTaskFlag) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    return runCatching { startActivity(intent) }
+        .onFailure { onError?.invoke(it) }
+        .isSuccess
+}

--- a/core/common-android/src/main/java/khs/onmi/core/common/android/SafeUri.kt
+++ b/core/common-android/src/main/java/khs/onmi/core/common/android/SafeUri.kt
@@ -9,10 +9,11 @@ fun Context.safeOpenUri(
     addNewTaskFlag: Boolean = false,
     onError: ((Throwable) -> Unit)? = null,
 ): Boolean {
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
-        if (addNewTaskFlag) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    }
-    return runCatching { startActivity(intent) }
-        .onFailure { onError?.invoke(it) }
+    return runCatching {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).apply {
+            if (addNewTaskFlag) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+    }.onFailure { onError?.invoke(it) }
         .isSuccess
 }

--- a/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
+++ b/feature/setting/src/main/java/khs/onmi/setting/screen/SettingScreen.kt
@@ -1,5 +1,6 @@
 package khs.onmi.setting.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -12,8 +13,9 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import khs.onmi.core.common.android.safeOpenUri
 import khs.onmi.core.designsystem.component.TopNavigationBar
 import khs.onmi.core.designsystem.icon.AllergiesIcon
 import khs.onmi.core.designsystem.icon.ArrowBackIcon
@@ -42,7 +44,7 @@ fun SettingScreen(
     onSkipWeekendToggleValueChanged: (value: Boolean) -> Unit,
     onShowNextDayInfoAfterDinnerValueChanged: (value: Boolean) -> Unit,
 ) {
-    val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
 
     ONMITheme { color, typography ->
         Column(
@@ -105,7 +107,18 @@ fun SettingScreen(
                                 trailing = { RightArrowIcon(tint = color.UnselectedPrimary) },
                                 text = "이용 약관",
                                 leading = { PaperIcon(tint = color.Black) },
-                                onClick = { uriHandler.openUri(WebLink.PolicyUrl) }
+                                onClick = {
+                                    context.safeOpenUri(
+                                        uri = WebLink.PolicyUrl,
+                                        onError = {
+                                            Toast.makeText(
+                                                context,
+                                                "브라우저를 열 수 없습니다.",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
+                                        }
+                                    )
+                                }
                             )
                         )
                     )

--- a/feature/widget/src/main/java/com/onmi/widget/util/launchApp.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/util/launchApp.kt
@@ -1,13 +1,8 @@
 package com.onmi.widget.util
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
+import khs.onmi.core.common.android.safeOpenUri
 
 fun Context.launchApp() {
-    val deepLinkUri = Uri.parse("onmi://root")
-    val intent = Intent(Intent.ACTION_VIEW, deepLinkUri)
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-    runCatching { this.startActivity(intent) }
+    safeOpenUri(uri = "onmi://root", addNewTaskFlag = true)
 }


### PR DESCRIPTION
## Summary
- Compose `AndroidUriHandler.openUri()`가 `ActivityNotFoundException`을 `IllegalArgumentException`으로 wrap하여 throw하는 문제로 일부 디바이스에서 설정 화면 "이용 약관" 탭 시 앱 크래시 발생 → 폴백 처리
- 외부 URI/Intent 호출의 안전 처리를 공통 유틸 `safeOpenUri`로 일원화 (이번 릴리즈 항목 후보)

## 변경 내역
### 신규
- `core/common-android/.../SafeUri.kt` — `Context.safeOpenUri(uri, addNewTaskFlag, onError)` 확장 함수
  - `runCatching` 으로 모든 예외 흡수
  - `onError` 콜백으로 호출처 자유 처리(Toast/로깅 등) — 미지정 시 무음 실패
  - `addNewTaskFlag` 로 비-Activity 컨텍스트(위젯/Service) 호환

### 적용
- `feature/setting/.../SettingScreen.kt` — `LocalUriHandler` 제거, `safeOpenUri` + Toast 폴백
- `feature/widget/.../launchApp.kt` — 기존 4줄 Intent 빌드 + `runCatching`을 `safeOpenUri` 한 줄 호출로 축소

## 원인 (Root Cause)
```kotlin
// androidx.compose.ui.platform.AndroidUriHandler
override fun openUri(uri: String) {
    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
    try { context.startActivity(intent) }
    catch (e: ActivityNotFoundException) {
        throw IllegalArgumentException("Activity chain not available for the given uri: $uri", e)
    }
}
```
브라우저 비활성화 / 손상된 시스템 / 일부 OEM 펌웨어 등 https `ACTION_VIEW` 핸들러 부재 환경에서 발생.

> 매니페스트 `<queries>` 추가만으로는 해결되지 않음 (https는 Android 11+ 패키지 가시성 자동 예외이지만, 실제 핸들러가 없으면 여전히 `ActivityNotFoundException` 발생)

## Test plan
- [ ] 정상 환경: 설정 → 이용 약관 탭 시 브라우저로 정책 URL 정상 오픈
- [ ] 핸들러 부재 환경(에뮬레이터에서 Chrome 비활성화): 탭 시 "브라우저를 열 수 없습니다." Toast 노출 + 크래시 미발생
- [ ] 위젯 탭 시 앱 정상 실행(딥링크 `onmi://root`)
- [ ] `:core:common-android`, `:feature:setting`, `:feature:widget` 컴파일 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)