### PR TITLE
🐛 :: 위젯 클릭 시 Glance ActionTrampoline 크래시 방지

### DIFF
--- a/feature/widget/src/main/java/com/onmi/widget/combined/CombinedWidget.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/combined/CombinedWidget.kt
@@ -37,7 +37,7 @@ import androidx.glance.layout.width
 import com.onmi.widget.components.MessageBox
 import com.onmi.widget.theme.ONMIWidgetColorScheme
 import com.onmi.widget.util.SuitText
-import com.onmi.widget.util.launchApp
+import com.onmi.widget.util.launchAppAction
 
 class CombinedWidget : GlanceAppWidget() {
     override val stateDefinition = CombinedStateDefinition
@@ -168,7 +168,7 @@ class CombinedWidget : GlanceAppWidget() {
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .clickable { context.launchApp() },
+                .clickable(launchAppAction()),
             content = {}
         )
     }

--- a/feature/widget/src/main/java/com/onmi/widget/components/MessageBox.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/components/MessageBox.kt
@@ -11,7 +11,7 @@ import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.fillMaxSize
 import com.onmi.widget.util.SuitText
-import com.onmi.widget.util.launchApp
+import com.onmi.widget.util.launchAppAction
 
 @Composable
 fun MessageBox(message: String) {
@@ -21,7 +21,7 @@ fun MessageBox(message: String) {
         modifier = GlanceModifier
             .fillMaxSize()
             .background(GlanceTheme.colors.onPrimary)
-            .clickable { context.launchApp() },
+            .clickable(launchAppAction()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/feature/widget/src/main/java/com/onmi/widget/meal/MealWidget.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/meal/MealWidget.kt
@@ -29,7 +29,7 @@ import androidx.glance.layout.padding
 import com.onmi.widget.components.MessageBox
 import com.onmi.widget.theme.ONMIWidgetColorScheme
 import com.onmi.widget.util.SuitText
-import com.onmi.widget.util.launchApp
+import com.onmi.widget.util.launchAppAction
 
 class MealWidget : GlanceAppWidget() {
     override val stateDefinition = MealInfoStateDefinition
@@ -102,7 +102,7 @@ class MealWidget : GlanceAppWidget() {
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .clickable { context.launchApp() },
+                .clickable(launchAppAction()),
             content = {}
         )
     }

--- a/feature/widget/src/main/java/com/onmi/widget/timetable/TimeTableWidget.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/timetable/TimeTableWidget.kt
@@ -32,7 +32,7 @@ import androidx.glance.layout.width
 import com.onmi.widget.components.MessageBox
 import com.onmi.widget.theme.ONMIWidgetColorScheme
 import com.onmi.widget.util.SuitText
-import com.onmi.widget.util.launchApp
+import com.onmi.widget.util.launchAppAction
 
 class TimeTableWidget : GlanceAppWidget() {
     override val stateDefinition = TimeTableInfoStateDefinition
@@ -99,7 +99,7 @@ private fun TimeTableWidgetContent(timeTable: List<String>) {
     Box(
         modifier = GlanceModifier
             .fillMaxSize()
-            .clickable { context.launchApp() },
+            .clickable(launchAppAction()),
         content = {}
     )
 }

--- a/feature/widget/src/main/java/com/onmi/widget/util/launchApp.kt
+++ b/feature/widget/src/main/java/com/onmi/widget/util/launchApp.kt
@@ -1,8 +1,14 @@
 package com.onmi.widget.util
 
-import android.content.Context
-import khs.onmi.core.common.android.safeOpenUri
+import android.content.Intent
+import android.net.Uri
+import androidx.glance.action.Action
+import androidx.glance.appwidget.action.actionStartActivity
 
-fun Context.launchApp() {
-    safeOpenUri(uri = "onmi://root", addNewTaskFlag = true)
-}
+// actionStartActivity는 명시 Intent를 PendingIntent로 직접 변환해 ActionTrampolineActivity를 거치지 않는다.
+// `clickable { ... }`(LambdaAction)은 trampoline을 경유하는데 일부 OEM/OS 조합에서 trampoline intent가
+// extras를 잃어 IllegalArgumentException("List adapter activity trampoline ...")로 크래시한다.
+fun launchAppAction(): Action = actionStartActivity(
+    Intent(Intent.ACTION_VIEW, Uri.parse("onmi://root"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+)


### PR DESCRIPTION
## 💡 개요
- Crashlytics Issue: `babbf348be7e1a6e02bf8b613922247b`
- 영향: 사용자 2명 / 세션 1회 / 이벤트 2건 (지난 90일, prod 1.7.1)
- 발생 환경: OnePlus 8 Pro / Android 11 (다른 OEM/구버전에도 잠재)

## 🔍 원인 (Root Cause)
스택 트레이스 핵심:
```
Caused by: java.lang.IllegalArgumentException: List adapter activity trampoline invoked without specifying target intent.
    at androidx.glance.appwidget.action.ActionTrampolineKt.launchTrampolineAction (ActionTrampoline.kt:93)
    at androidx.glance.appwidget.action.ActionTrampolineActivity.onCreate (ActionTrampolineActivity.kt:31)
```

위젯에서 `clickable { context.launchApp() }` (LambdaAction)는 androidx.glance가 PendingIntent로 만들 때 `ActionTrampolineActivity`를 경유한다. trampoline activity는 받은 Intent의 extras로 어떤 lambda를 실행할지 결정하는데, 일부 OEM/OS 조합(OnePlus 8 Pro / Android 11 확인)에서 PendingIntent extras가 유실되어 `ActionTypeIntentKey`를 찾지 못하고 `requireNotNull` 지점에서 IllegalArgumentException으로 즉시 크래시한다.

## 📃 작업내용
- `Context.launchApp()` (LambdaAction 트리거)을 제거하고 `launchAppAction(): Action`로 대체
- 신규 Action은 `androidx.glance.appwidget.action.actionStartActivity(intent)`로 명시 Intent를 PendingIntent로 직접 변환 → ActionTrampolineActivity 경유 자체를 제거
- 위젯 4곳(`MealWidget`, `CombinedWidget`, `TimeTableWidget`, `MessageBox`)의 `.clickable { context.launchApp() }`를 `.clickable(launchAppAction())`로 일괄 교체

## 🔀 변경사항
- `feature/widget/src/main/java/com/onmi/widget/util/launchApp.kt` — `Context.launchApp()` 제거, `launchAppAction(): Action` 신규 (Intent.ACTION_VIEW + `onmi://root` + FLAG_ACTIVITY_NEW_TASK)
- `feature/widget/src/main/java/com/onmi/widget/meal/MealWidget.kt` — clickable 호출 교체
- `feature/widget/src/main/java/com/onmi/widget/combined/CombinedWidget.kt` — clickable 호출 교체
- `feature/widget/src/main/java/com/onmi/widget/timetable/TimeTableWidget.kt` — clickable 호출 교체
- `feature/widget/src/main/java/com/onmi/widget/components/MessageBox.kt` — clickable 호출 교체

## 🧪 Test plan
- [ ] 정상 환경: 위젯(meal / timetable / combined) 탭 시 앱 정상 진입 (`onmi://root` 딥링크 매칭 확인)
- [ ] Loading / Unavailable 상태의 MessageBox 탭 시 앱 정상 진입
- [ ] OnePlus 또는 유사 OEM 디바이스 / Android 11 환경에서 위젯 탭 반복 시 크래시 미발생
- [x] `:feature:widget:compileDebugKotlin` / `:app:compileDebugKotlin` 통과 확인

## 🎸 기타
- 기존 `safeOpenUri` 유틸은 Setting 화면(외부 정책 URL 오픈) 등에서 여전히 사용되므로 제거하지 않음.
- Firebase Crashlytics 이슈 상태/노트는 본 PR에서 자동 갱신하지 않음. 필요 시 issueId(`babbf348be7e1a6e02bf8b613922247b`)로 수동 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* **Refactor**
  * 여러 위젯의 클릭 이벤트 처리 메커니즘을 표준화된 액션 기반 방식으로 개선했습니다.
  * 위젯 상호작용 트리거 방식을 더 안정적이고 일관된 구현으로 전환했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->