### PR TITLE
✨ :: 디버그 빌드에서 급식/시간표 조회 날짜 선택 기능 추가

### DIFF
--- a/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
+++ b/domain/src/main/java/com/onmi/domain/util/DateUtils.kt
@@ -11,12 +11,34 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 object DateUtils {
     fun convertMillisToDateString(millis: Long): String {
         val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
         val date = Date(millis)
         return formatter.format(date)
+    }
+
+    /**
+     * UTC 자정 기준 millis 를 yyyyMMdd 로 변환한다.
+     * Compose Material3 DatePicker 가 선택 날짜를 UTC 자정으로 돌려주기 때문에,
+     * 기기 타임존을 따르는 [convertMillisToDateString] 을 쓰면 UTC 음수 오프셋 지역에서 하루가 밀린다.
+     */
+    fun convertUtcMillisToDateString(millis: Long): String {
+        val formatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault()).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        return formatter.format(Date(millis))
+    }
+
+    /* [convertUtcMillisToDateString] 의 역변환. 형식이 잘못되면 null 을 돌려준다. */
+    fun convertDateStringToUtcMillis(dateString: String): Long? {
+        return runCatching {
+            SimpleDateFormat("yyyyMMdd", Locale.getDefault()).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }.parse(dateString)?.time
+        }.getOrNull()
     }
 
     fun checkIsWeekend(): Boolean {

--- a/feature/main/src/main/java/khs/onmi/main/component/DebugDatePickerDialog.kt
+++ b/feature/main/src/main/java/khs/onmi/main/component/DebugDatePickerDialog.kt
@@ -1,0 +1,48 @@
+package khs.onmi.main.component
+
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+
+/**
+ * 디버그 빌드 전용 날짜 선택 다이얼로그.
+ * 여기서 고른 날짜는 메인 화면의 급식·시간표 조회에 강제로 적용된다.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DebugDatePickerDialog(
+    initialSelectedDateMillis: Long?,
+    onDateSelected: (utcMillis: Long) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = initialSelectedDateMillis
+    )
+
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = { datePickerState.selectedDateMillis?.let(onDateSelected) },
+                enabled = datePickerState.selectedDateMillis != null
+            ) {
+                Text(text = "확인")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onReset) {
+                Text(text = "오늘로 초기화")
+            }
+            TextButton(onClick = onDismiss) {
+                Text(text = "취소")
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}

--- a/feature/main/src/main/java/khs/onmi/main/screen/MainRoute.kt
+++ b/feature/main/src/main/java/khs/onmi/main/screen/MainRoute.kt
@@ -1,5 +1,6 @@
 package khs.onmi.main.screen
 
+import android.content.pm.ApplicationInfo
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
@@ -20,6 +21,7 @@ fun MainRoute(
 ) {
     val activity = LocalActivity.current
     val context = LocalContext.current
+    val isDebuggable = context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
     var backPressedTime: Long = 0
 
     BackHandler {
@@ -39,8 +41,11 @@ fun MainRoute(
 
     MainScreen(
         uiState = uiState,
+        isDebuggable = isDebuggable,
         navigate = navController::navigate,
-        reloadTimeTable = viewModel::getTodayTimeTable,
-        reloadMeal = viewModel::getTodayMeals
+        reloadTimeTable = viewModel::reloadTimeTable,
+        reloadMeal = viewModel::reloadMeals,
+        onDebugDateSelected = viewModel::setDebugTargetDate,
+        onDebugDateReset = viewModel::clearDebugTargetDate
     )
 }

--- a/feature/main/src/main/java/khs/onmi/main/screen/MainScreen.kt
+++ b/feature/main/src/main/java/khs/onmi/main/screen/MainScreen.kt
@@ -15,17 +15,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.onmi.domain.util.DateUtils
 import khs.onmi.core.common.android.EventLogger
 import khs.onmi.core.common.android.SelectedType
 import khs.onmi.core.designsystem.component.InfoCard
 import khs.onmi.core.designsystem.component.TopNavigationBar
+import khs.onmi.core.designsystem.icon.CalendarIcon
 import khs.onmi.core.designsystem.icon.SettingIcon
 import khs.onmi.core.designsystem.theme.ONMITheme
 import khs.onmi.core.designsystem.utils.WrappedIconButton
+import khs.onmi.main.component.DebugDatePickerDialog
 import khs.onmi.main.component.MainTabRow
 import khs.onmi.main.component.MealsSection
 import khs.onmi.main.component.TimeTableSection
@@ -35,12 +39,16 @@ import khs.onmi.navigation.ONMINavRoutes
 @Composable
 fun MainScreen(
     uiState: MainState,
+    isDebuggable: Boolean,
     navigate: (route: String) -> Unit,
     reloadTimeTable: () -> Unit,
     reloadMeal: () -> Unit,
+    onDebugDateSelected: (utcMillis: Long) -> Unit,
+    onDebugDateReset: () -> Unit,
 ) {
     val pagerState = rememberPagerState(pageCount = { 2 })
     var dragStartPage by remember { mutableIntStateOf(pagerState.currentPage) }
+    var isDebugDatePickerVisible by remember { mutableStateOf(false) }
 
     // 메인페이지 Pager 로깅 관련 코드
     LaunchedEffect(pagerState) {
@@ -75,6 +83,11 @@ fun MainScreen(
                     )
                 },
                 trailing = {
+                    if (isDebuggable) {
+                        WrappedIconButton(onClick = { isDebugDatePickerVisible = true }) {
+                            CalendarIcon(tint = color.Black)
+                        }
+                    }
                     WrappedIconButton(onClick = { navigate(ONMINavRoutes.SETTING) }) {
                         SettingIcon(tint = color.Black)
                     }
@@ -113,6 +126,23 @@ fun MainScreen(
                     )
                 }
             }
+        }
+
+        if (isDebuggable && isDebugDatePickerVisible) {
+            DebugDatePickerDialog(
+                initialSelectedDateMillis = uiState.rawTargetDate
+                    .takeIf { it.isNotBlank() }
+                    ?.let(DateUtils::convertDateStringToUtcMillis),
+                onDateSelected = { utcMillis ->
+                    onDebugDateSelected(utcMillis)
+                    isDebugDatePickerVisible = false
+                },
+                onReset = {
+                    onDebugDateReset()
+                    isDebugDatePickerVisible = false
+                },
+                onDismiss = { isDebugDatePickerVisible = false }
+            )
         }
     }
 }

--- a/feature/main/src/main/java/khs/onmi/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/khs/onmi/main/viewmodel/MainViewModel.kt
@@ -15,6 +15,7 @@ import khs.onmi.main.viewmodel.container.MainSideEffect
 import khs.onmi.main.viewmodel.container.MainState
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -55,11 +56,15 @@ class MainViewModel @Inject constructor(
             intent {
                 postSideEffect(MainSideEffect.ShowToast("메인화면 정보를 가져오는데 문제가 발생했습니다."))
             }
-        }.collect { (targetDate, userEntity) ->
+        }.collect { (calculatedDate, userEntity) ->
+            /* 디버그 모드에서 날짜를 지정했다면 자동 계산 결과보다 우선한다. */
+            val targetDate = container.stateFlow.value.debugTargetDate ?: calculatedDate
+
             intent {
                 reduce {
                     state.copy(
                         targetDate = DateUtils.convertToMonthDay(targetDate),
+                        rawTargetDate = targetDate,
                         schoolName = userEntity.schoolName,
                         grade = userEntity.grade,
                         `class` = userEntity.classroom
@@ -67,36 +72,62 @@ class MainViewModel @Inject constructor(
                 }
             }
 
-            launch { getTodayTimeTable(targetDate = targetDate) }
-            launch { getTodayMeals(targetDate = targetDate) }
+            getTodayTimeTable(targetDate = targetDate)
+            getTodayMeals(targetDate = targetDate)
         }
     }
 
-    fun getTodayTimeTable(targetDate: String = "") = intent {
+    fun reloadTimeTable() = intent {
+        getTodayTimeTable(targetDate = state.rawTargetDate)
+    }
+
+    fun reloadMeals() = intent {
+        getTodayMeals(targetDate = state.rawTargetDate)
+    }
+
+    /* 디버그 모드 전용. Compose DatePicker 가 돌려주는 UTC 자정 millis 를 받는다. */
+    fun setDebugTargetDate(utcMillis: Long) =
+        applyDebugTargetDate(DateUtils.convertUtcMillisToDateString(utcMillis))
+
+    /* 디버그 모드 전용. 강제 지정한 날짜를 해제하고 원래 계산된 날짜로 되돌린다. */
+    fun clearDebugTargetDate() = applyDebugTargetDate(null)
+
+    private fun applyDebugTargetDate(date: String?) = intent {
+        val targetDate = date ?: calculateTargetDateUseCase().first()
+
+        reduce {
+            state.copy(
+                targetDate = DateUtils.convertToMonthDay(targetDate),
+                rawTargetDate = targetDate,
+                debugTargetDate = date
+            )
+        }
+
+        getTodayTimeTable(targetDate = targetDate)
+        getTodayMeals(targetDate = targetDate)
+    }
+
+    private fun getTodayTimeTable(targetDate: String) = intent {
         reduce {
             state.copy(timeTableState = TimeTableState.Loading)
         }
 
-        viewModelScope.launch {
-            val response = getTimeTableUseCase(targetDate = targetDate)
+        val response = getTimeTableUseCase(targetDate = targetDate)
 
-            reduce {
-                state.copy(timeTableState = response)
-            }
+        reduce {
+            state.copy(timeTableState = response)
         }
     }
 
-    fun getTodayMeals(targetDate: String = "") = intent {
+    private fun getTodayMeals(targetDate: String) = intent {
         reduce {
             state.copy(mealState = MealState.Loading)
         }
 
-        viewModelScope.launch {
-            val response = getMealsUseCase(targetDate = targetDate)
+        val response = getMealsUseCase(targetDate = targetDate)
 
-            reduce {
-                state.copy(mealState = response)
-            }
+        reduce {
+            state.copy(mealState = response)
         }
     }
 }

--- a/feature/main/src/main/java/khs/onmi/main/viewmodel/container/MainState.kt
+++ b/feature/main/src/main/java/khs/onmi/main/viewmodel/container/MainState.kt
@@ -8,6 +8,10 @@ data class MainState(
     val grade: Int = 0,
     val `class`: Int = 0,
     val targetDate: String = "",
+    /* 실제 조회에 사용한 날짜(yyyyMMdd). 재시도·디버그 날짜 선택 시 기준으로 쓴다. */
+    val rawTargetDate: String = "",
+    /* 디버그 모드에서 강제 지정한 날짜(yyyyMMdd). 지정하지 않았으면 null */
+    val debugTargetDate: String? = null,
     val mealState: MealState = MealState.Loading,
     val timeTableState: TimeTableState = TimeTableState.Loading,
     val selectedAllergyIds: Set<Int> = emptySet(),


### PR DESCRIPTION
## 💡 개요
기기 시스템 시간을 바꾸지 않고도 특정 날짜의 급식·시간표를 확인할 수 있도록, **디버그 빌드 한정** 날짜 선택 디버거를 추가합니다.

기존에는 조회 날짜가 `CalculateTargetDateUseCase`로 자동 결정되기만 해서 "3월 임시 시간표", "주말", "급식 없는 날" 같은 케이스를 확인하려면 기기 시간을 바꾸는 수밖에 없었습니다. 이 방식은 느릴 뿐 아니라 WorkManager·Firebase 동작까지 함께 뒤틀립니다.

## 📃 작업내용
- 메인 상단바 설정 아이콘 왼쪽에 캘린더 아이콘을 노출하고, 탭하면 Material3 `DatePickerDialog`를 띄웁니다.
- 노출 여부는 `applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE`로 판별합니다. `MainActivity`의 DEBUG 리본과 동일한 방식이라 gradle `buildConfig` 활성화가 필요 없습니다.
- 선택한 날짜는 `MainState`에만 보관하고, 기존 `GetMealsUseCase(targetDate)` / `GetTimeTableUseCase(targetDate)`에 그대로 넘깁니다. 새 저장소·DI·영속화 계층을 추가하지 않았습니다.
- `오늘로 초기화`를 누르면 `calculateTargetDateUseCase()`로 원래 날짜를 다시 구해 복귀합니다.
- **함께 수정**: 재시도 버튼이 빈 날짜(`""`)로 API를 호출하던 문제. `reloadTimeTable`이 `viewModel::getTodayTimeTable`(기본값 `targetDate = ""`)에 바인딩돼 있었습니다. `rawTargetDate`를 기준으로 재조회하도록 바꿨습니다.

## 🔀 변경사항
- `domain/util/DateUtils.kt` — `convertUtcMillisToDateString` / `convertDateStringToUtcMillis` 추가. `DatePicker`가 선택 날짜를 **UTC 자정** 기준 millis로 돌려주는데, 기기 타임존을 따르는 기존 `convertMillisToDateString`을 쓰면 UTC 음수 오프셋 지역에서 하루가 밀립니다. 기존 함수는 그대로 뒀습니다.
- `feature/main/component/DebugDatePickerDialog.kt` (신규) — `DatePickerDialog` + `rememberDatePickerState`. 버튼은 `확인` / `오늘로 초기화` / `취소`.
- `feature/main/viewmodel/container/MainState.kt` — `rawTargetDate`(실제 조회에 쓴 `yyyyMMdd`), `debugTargetDate`(강제 지정 날짜) 필드 추가.
- `feature/main/viewmodel/MainViewModel.kt` — `setDebugTargetDate` / `clearDebugTargetDate` 추가. `getTodayTimeTable` / `getTodayMeals`를 `private`으로 내리고 기본값 `""`를 제거, 공개 API는 `reloadTimeTable` / `reloadMeals`로 정리. 설정 변경 등으로 `settingMainScreen` 플로우가 다시 흘러도 `debugTargetDate`가 자동 계산 결과보다 우선하도록 했습니다.
- `feature/main/screen/MainScreen.kt` — `isDebuggable`일 때만 캘린더 아이콘과 다이얼로그를 렌더링. 기존 `CalendarIcon` / `WrappedIconButton` 재사용.
- `feature/main/screen/MainRoute.kt` — `isDebuggable` 계산 및 콜백 연결.

## 🧪 Test plan
- [x] `assembleDebug` / `assembleRelease` 클린 빌드 통과
- [ ] 디버그 빌드에서 상단바에 캘린더 아이콘이 보인다
- [ ] **릴리즈 빌드에서는 아이콘이 보이지 않는다**
- [ ] 과거 평일 선택 → InfoCard 날짜 표기와 급식·시간표가 해당 날짜 데이터로 바뀐다
- [ ] 주말 선택 → 급식 탭이 `DataEmpty` 상태를 보여준다
- [ ] 3월 날짜 선택 → 시간표 탭이 `TemporaryTimeTable` 문구를 보여준다
- [ ] `오늘로 초기화` → 오늘 데이터로 복귀
- [ ] 에러 상태에서 재시도 버튼을 눌러도 선택한 날짜가 유지된다

## 🎸 기타
- **위젯은 적용 범위에서 제외했습니다.** 위젯 Worker는 화면과 별개로 실행되어 `ViewModel`이 값을 전달할 통로가 없고, 이를 위해 DataStore 영속화 계층을 만드는 것은 디버그 도구 대비 변경 범위가 과했습니다. 위젯은 기존대로 항상 오늘 기준입니다.
- 디버그 날짜는 앱을 재시작하면 초기화됩니다. 날짜를 바꿔둔 걸 잊고 다른 확인을 하다 헷갈릴 일이 없어 디버그 도구로는 오히려 이쪽이 안전하다고 판단했습니다.
- `DatePickerDialog`는 앱의 `ONMITheme`가 아니라 Material3 기본 테마로 그려집니다. 디버그 전용 UI라 별도 스타일링은 하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
